### PR TITLE
Make the Lazy basic implementation much faster...

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,4 +1,5 @@
 {
+    "version": "2.0.0",
     "summary": "Basic primitives for working with laziness",
     "repository": "http://github.com/elm-lang/lazy.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,4 @@
 {
-    "version": "2.0.0",
     "summary": "Basic primitives for working with laziness",
     "repository": "http://github.com/elm-lang/lazy.git",
     "license": "BSD3",

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -1,9 +1,18 @@
-module Lazy exposing
-    ( Lazy
-    , force, lazy, lazyFromValue
-    , map, map2, map3, map4, map5
-    , apply, andThen, fix
-    )
+module Lazy
+    exposing
+        ( Lazy
+        , force
+        , lazy
+        , lazyFromValue
+        , map
+        , map2
+        , map3
+        , map4
+        , map5
+        , apply
+        , andThen
+        , fix
+        )
 
 {-| This library lets you delay a computation until later.
 
@@ -23,14 +32,14 @@ module Lazy exposing
 import Native.Lazy
 
 
-
 -- PRIMITIVES
 
 
-{-| A wrapper around a value that will be lazily evaluated. -}
+{-| A wrapper around a value that will be lazily evaluated.
+-}
 type Lazy a
-  = Evaluated a
-  | Unevaluated (() -> a)
+    = Evaluated a
+    | Unevaluated (() -> a)
 
 
 {-| Delay the evaluation of a value until later. For example, maybe we will
@@ -45,7 +54,7 @@ Now we only pay for `lazySum` if we actually need it.
 -}
 lazy : (() -> a) -> Lazy a
 lazy thunk =
-  Native.Lazy.lazy thunk
+    Native.Lazy.lazy thunk
 
 
 {-| `lazyFromValue' Sets the created Lazy a to an already evaluated value.
@@ -53,7 +62,6 @@ For example, maybe we want to set the tail of a lazy list to an Empty node so
 there is no need to defer the calculation as it is a simple constant:
 
     type LazyList a = Empty | Cons a (Lazy (LazyList a))
-
     shortLazyList : LazyList Int
     shortLazyList =
       Cons 1 <| lazyFromValue Empty
@@ -63,7 +71,7 @@ force without calling an evaluation functtion.
 -}
 lazyFromValue : a -> Lazy a
 lazyFromValue v =
-  Native.Lazy.lazyFromValue v
+    Native.Lazy.lazyFromValue v
 
 
 {-| Force the evaluation of a lazy value. This means we only pay for the
@@ -72,7 +80,6 @@ computation when we need it. Here is a rather contrived example.
     lazySum : Lazy Int
     lazySum =
         lazy (\() -> List.sum [1..1000000])
-
     sums : (Int, Int, Int)
     sums =
         (force lazySum, force lazySum, force lazySum)
@@ -84,7 +91,7 @@ value in memory.
 -}
 force : Lazy a -> a
 force (Lazy thunk) =
-  thunk()
+    thunk ()
 
 
 
@@ -102,7 +109,7 @@ finally forced.
 -}
 map : (a -> b) -> Lazy a -> Lazy b
 map f a =
-  lazy (\() -> f (force a))
+    lazy (\() -> f (force a))
 
 
 {-| Lazily apply a function to two lazy values.
@@ -110,33 +117,31 @@ map f a =
     lazySum : Lazy Int
     lazySum =
         lazy (\() -> List.sum [1..1000000])
-
     lazySumPair : Lazy (Int, Int)
     lazySumPair =
         map2 (,) lazySum lazySum
-
 -}
 map2 : (a -> b -> result) -> Lazy a -> Lazy b -> Lazy result
 map2 f a b =
-  lazy (\() -> f (force a) (force b))
+    lazy (\() -> f (force a) (force b))
 
 
-{-|-}
+{-| -}
 map3 : (a -> b -> c -> result) -> Lazy a -> Lazy b -> Lazy c -> Lazy result
 map3 f a b c =
-  lazy (\() -> f (force a) (force b) (force c))
+    lazy (\() -> f (force a) (force b) (force c))
 
 
-{-|-}
+{-| -}
 map4 : (a -> b -> c -> d -> result) -> Lazy a -> Lazy b -> Lazy c -> Lazy d -> Lazy result
 map4 f a b c d =
-  lazy (\() -> f (force a) (force b) (force c) (force d))
+    lazy (\() -> f (force a) (force b) (force c) (force d))
 
 
-{-|-}
+{-| -}
 map5 : (a -> b -> c -> d -> e -> result) -> Lazy a -> Lazy b -> Lazy c -> Lazy d -> Lazy e -> Lazy result
 map5 f a b c d e =
-  lazy (\() -> f (force a) (force b) (force c) (force d) (force e))
+    lazy (\() -> f (force a) (force b) (force c) (force d) (force e))
 
 
 {-| Lazily apply a lazy function to a lazy value. This is pretty rare on its
@@ -149,7 +154,7 @@ It is not the most beautiful, but it is equivalent and will let you create
 -}
 apply : Lazy (a -> b) -> Lazy a -> Lazy b
 apply f x =
-  lazy (\() -> (force f) (force x))
+    lazy (\() -> (force f) (force x))
 
 
 {-| Lazily chain together lazy computations, for when you have a series of
@@ -157,11 +162,9 @@ steps that all need to be performed lazily. This can be nice when you need to
 pattern match on a value, for example, when appending lazy lists:
 
     type LazyList a = Empty | Cons a (Lazy (LazyList a))
-
     cons : a -> Lazy (LazyList a) -> Lazy (LazyList a)
     cons v lazylist =
       Lazy.map (\x -> Cons v <| lazy (\() -> x)) lazylist
-
     append : Lazy (LazyList a) -> Lazy (LazyList a) -> Lazy (LazyList a)
     append list1 list2 =
       let
@@ -175,7 +178,6 @@ pattern match on a value, for example, when appending lazy lists:
             lazylist1 |> Lazy.andThen appendHelp
       in appendi list1
 
-
 By using `andThen` we ensure that neither `lazyList1` nor `lazyList2` are forced
 before they are needed. So as written, the `append` function delays the pattern
 matching until later.
@@ -187,7 +189,7 @@ due to the number of force/thunk/lazy chains of function calls/composition neede
 -}
 andThen : (a -> Lazy b) -> Lazy a -> Lazy b
 andThen callback a =
-  lazy (\() -> force (callback (force a)))
+    lazy (\() -> force (callback (force a)))
 
 
 
@@ -205,21 +207,24 @@ For example, using a function that produces a lazy list (delayed execution) of
 all the 32-bit `Int' natural numbers (with upper bounds check) code as follows::
 
     type LazyList a = Empty | Cons a (Lazy (LazyList a))
-
     plus1 ll =
       case ll of
         Empty -> Empty
         Cons hd tl ->
           if hd == ox7FFFFFFF then Empty else
           Cons (hd + 1) <| lazy <| \() -> plus1 <| force tl
-
     nat32fs() =
       fix <| plus1 << Cons -1
-    
+
 By using `fix' we get a recursive (lazy) chain of computations
 producing the lazy list of all naturals in this case, although this is a
 contrived case and there are more direct ways to accomplish this task.
 -}
 fix : (Lazy a -> a) -> a
 fix f =
-  let r = lazy <| \() -> f r in force r
+    let
+        r =
+            lazy <| \() -> f r
+    in
+        force r
+

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -42,7 +42,7 @@ Now we only pay for `lazySum` if we actually need it.
 -}
 lazy : (() -> a) -> Lazy a
 lazy thunk =
-  Unevaluated thunk
+  Native.Lazy.lazy thunk
 
 
 {-| `lazyFromValue' Sets the created Lazy a to an already evaluated value.
@@ -60,7 +60,7 @@ force without calling an evaluation functtion.
 -}
 lazyFromValue : a -> Lazy a
 lazyFromValue v =
-  Evaluated v
+  Native.Lazy.lazyFromValue v
 
 
 {-| Force the evaluation of a lazy value. This means we only pay for the
@@ -80,10 +80,8 @@ the first one, but all the rest are very cheap, basically just looking up a
 value in memory.
 -}
 force : Lazy a -> a
-force lzy =
-  case lzy of
-    Evaluated a -> a
-    Unevaluated _ -> Native.Lazy.memoize lzy
+force (Lazy thunk) =
+  thunk()
 
 
 

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -49,15 +49,13 @@ lazy thunk =
 For example, maybe we want to set the tail of a lazy list to an Empty node so
 there is no need to defer the calculation as it is a simple constant:
 
-    type LazyListNode a = Empty | Cons a (LazyList a)
-    type alias LasyList a = Lazy (LazyListNode a)
+    type LazyList a = Empty | Cons a (Lazy (LazyList a))
 
     shortLazyList : LazyList Int
     shortLazyList =
-      lazy <| Cons 1 <| lazyFromValue Empty
+      Cons 1 <| lazyFromValue Empty
 
-Now the overall shortLazyList is lazy in case the head of the list is complex to
-calculate (unlike here) but the tail of the shortLazyList is immediately available to
+Now the tail of the shortLazyList is immediately available to
 force without calling an evaluation functtion.
 -}
 lazyFromValue : a -> Lazy a

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -38,8 +38,7 @@ import Native.Lazy
 {-| A wrapper around a value that will be lazily evaluated.
 -}
 type Lazy a
-    = Evaluated a
-    | Unevaluated (() -> a)
+    = Lazy (() -> a)
 
 
 {-| Delay the evaluation of a value until later. For example, maybe we will

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -1,6 +1,6 @@
 module Lazy exposing
     ( Lazy
-    , force, lazy
+    , force, lazy, lazyFromValue
     , map, map2, map3, map4, map5
     , apply, andThen
     )
@@ -8,7 +8,7 @@ module Lazy exposing
 {-| This library lets you delay a computation until later.
 
 # Basics
-@docs Lazy, lazy, force
+@docs Lazy, lazy, lazyFromValue, force
 
 # Mapping
 @docs map, map2, map3, map4, map5
@@ -43,6 +43,26 @@ Now we only pay for `lazySum` if we actually need it.
 lazy : (() -> a) -> Lazy a
 lazy thunk =
   Unevaluated thunk
+
+
+{-| `lazyFromValue' Sets the created Lazy a to an already evaluated value.
+For example, maybe we want to set the tail of a lazy list to an Empty node so
+there is no need to defer the calculation as it is a simple constant:
+
+    type LazyListNode a = Empty | Cons a (LazyList a)
+    type alias LasyList a = Lazy (LazyListNode a)
+
+    shortLazyList : LazyList Int
+    shortLazyList =
+      lazy <| Cons 1 <| lazyFromValue Empty
+
+Now the overall shortLazyList is lazy in case the head of the list is complex to
+calculate (unlike here) but the tail of the shortLazyList is immediately available to
+force without calling an evaluation functtion.
+-}
+lazyFromValue : a -> Lazy a
+lazyFromValue v =
+  Evaluated v
 
 
 {-| Force the evaluation of a lazy value. This means we only pay for the

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -25,8 +25,9 @@ import Native.Lazy
 
 
 {-| A wrapper around a value that will be lazily evaluated. -}
-type Lazy a =
-  Lazy (() -> a)
+type Lazy a
+  = Evaluated a
+  | Unevaluated (() -> a)
 
 
 {-| Delay the evaluation of a value until later. For example, maybe we will
@@ -41,7 +42,7 @@ Now we only pay for `lazySum` if we actually need it.
 -}
 lazy : (() -> a) -> Lazy a
 lazy thunk =
-  Lazy (Native.Lazy.memoize thunk)
+  Unevaluated thunk
 
 
 {-| Force the evaluation of a lazy value. This means we only pay for the
@@ -61,8 +62,10 @@ the first one, but all the rest are very cheap, basically just looking up a
 value in memory.
 -}
 force : Lazy a -> a
-force (Lazy thunk) =
-  thunk ()
+force lzy =
+  case lzy of
+    Evaluated a -> a
+    Unevaluated _ -> Native.Lazy.memoize lzy
 
 
 

--- a/src/Native/Lazy.js
+++ b/src/Native/Lazy.js
@@ -1,18 +1,39 @@
 var _elm_lang$lazy$Native_Lazy = function() {
 
-// mutates `lzy` Unevaluated thunk into Evaluated value, returning value.
-function memoize(lzy) {
-    if (lzy.ctor === 'Evaluating')
-        throw Error("Lazy.memoize:  recursive evaluation error!!!");
-    lzy.ctor = 'Evaluating';
-    var v = lzy._0(lzy); // dummy placeholder arg
-    lzy.ctor = 'Evaluated';
-    lzy._0 = v;
-    return v;
+// mutates inside a JS Closure so Elm can't see it.  IIFE helps Chrome speed.
+var memoize = function() {
+    return function(thunk, value) {
+        var _tu;
+        if (value === undefined)
+            _tu = { ctor: 'Unevaluated', _0: thunk }
+        else
+            _tu = { ctor: 'Evaluated', _0: value };
+        return function () {
+            var tag = _tu.ctor;
+            var v = _tu._0;
+            if (tag === 'Evaluating')
+                throw Error("Lazy.force:  recursive evaluation detected!!!");
+            if (tag == 'Unevaluated') {
+                _tu.ctor = 'Evaluating';
+                v = v();
+                _tu = { ctor: 'Evaluated', _0: v };
+            }
+            return v;
+        }
+    };
+}();
+
+function lazy(thunk) {
+    return { ctor: 'Lazy', _0: memoize(thunk, undefined) };
+}
+
+function lazyFromValue(v) {
+    return { ctor: 'Lazy', _0: memoize(undefined, v) };
 }
 
 return {
-    memoize: memoize
+    lazy: lazy,
+    lazyFromValue: lazyFromValue
 };
 
 }();

--- a/src/Native/Lazy.js
+++ b/src/Native/Lazy.js
@@ -11,9 +11,9 @@ var memoize = function() {
         return function () {
             var tag = _tu.ctor;
             var v = _tu._0;
-            if (tag === 'Evaluating')
-                throw Error("Lazy.force:  recursive evaluation detected!!!");
-            if (tag == 'Unevaluated') {
+            if (tag !== 'Evaluated') {
+                if (tag === 'Evaluating')
+                    throw Error("Lazy.force:  recursive evaluation detected!!!");
                 _tu.ctor = 'Evaluating';
                 v = v();
                 _tu = { ctor: 'Evaluated', _0: v };

--- a/src/Native/Lazy.js
+++ b/src/Native/Lazy.js
@@ -1,16 +1,14 @@
 var _elm_lang$lazy$Native_Lazy = function() {
 
-function memoize(thunk)
-{
-    var value;
-    var isForced = false;
-    return function(tuple0) {
-        if (!isForced) {
-            value = thunk(tuple0);
-            isForced = true;
-        }
-        return value;
-    };
+// mutates `lzy` Unevaluated thunk into Evaluated value, returning value.
+function memoize(lzy) {
+    if (lzy.ctor === 'Evaluating')
+        throw Error("Lazy.memoize:  recursive evaluation error!!!");
+    lzy.ctor = 'Evaluating';
+    var v = lzy._0(lzy); // dummy placeholder arg
+    lzy.ctor = 'Evaluated';
+    lzy._0 = v;
+    return v;
 }
 
 return {


### PR DESCRIPTION
The current JavaScript Native "memoize" function works by returning a nested forcer function when the outer "memoize" function is called to initialize the representation of the `Lazy` type with the thunk argument so that the evaluated data will later be stored as a local variable within the outer "memoize" function's scope when the returned inner forcer function is called.  This scheme of bulding a new nested inner function "on-the-fly" every time a new `Lazy` is initialized is very costly in execution time when run on many current main stream browsers such as Chrome 55:  http://jsperf.com/iifes-vs-nested-functions/4.

In order to speed this up for some browsers, <s>the generic `Lazy` type is changed to an Elm Tagged Union so that the `force` function can call the Native JS "memoize" function on that type without needing to create any new functions.</s> so the code was tuned to use an Immediately Invoked Function Expression (IIFE) in order to produce somewhat better speed for some browsers, such as current Chrome.

As an added benefit, the Native JS "memoize" function can check for recursive evaluation of the thunk and throw an error early rather than waiting for a stack overflow on the infinite loop with very little cost
in execution time.

This change affects <s>the `Lazy a` generic type, </s>the `lazy` type constructor function, and the `force` function as well as the Native JS "memoize" function; however, it makes no changes to the API of the Lazy
library module.

This speed can be verified by timing the enumeration of the following simple natural number lazy list sequence producing function as per the following code:

    type List a = Node a (Lazy (List a))

    nat32s : () -> List Int
    nat32s() =
      let nat32si n =
        Node n << lazy <| \() -> nat32si (n + 1)
      in nat32si 0
    
    nthnat32 : Int -> String
    nthnat32 n =
      let nthnati n nts =
        case nts of
          Node _ tl ->
            if n <= 0 then 
              case nts of
                Node hd _ -> toString hd else
            nthnati (n - 1) (force tl)
      in nthnati n (nat32s())

When run using the (latest) proposed changes compared to with the original code, running `nthnat32 999999` (one million iterations), this test code is faster by about up to two and a half times for Chrome 55 Stable, but doesn't have much of an affect on Firefox 51 Stable or Microsoft Edge 38.14393.0.0,  It is suspected that the problem with Chrome may be related to cache/heap/garbage collection, as the older version would get increasingly slower with extended repeated use of the `Lazy` type.  This new version tends to better maintain the same performance.  However, use the `Lazy` on Chrome is still slower than for Firefox, which is considerably slower than Edge, so there is still a considerable range of performance dependent on browser used of about three times.

As well, documentation is corrected for the erroneous `andThen' function example which could not be compiled due to errors and a note added for potential implementers of a `Lazy LazyList a' type that there is a very high execution time performance cost to adding the extra `Lazy' wrapper and implementing `cons' and `append' as in this example which is required to avoid "The Halting Problem" when the resulting `Lazy (LazyList a)` type is used to build infinite lazy lists..

Finally, a `Lazy` version of `fix` is provided (extending the API), that can by used to create recursion when passed a function of the accepted form; this has an advantage over the usual implementation of `fix` for strict strongly-typed languages such as Elm in that it uses `lazy`/`force` in its implementation and thus enjoys the benefits of recursive evaluation checks introduced with this PR.  On the other hand, it cannot be used for ordinary recursion with an included recursion limit as ordinary `fix` can be (and thus building stack), as that will be automatically detected and an exception thrown if it is tried with this function.  If one needs this behavior, a conventional `fix` should be used, although the code where that form of `fix` is used can often be written to not require `fix` at all (conventional function TCO'd recursive loops).